### PR TITLE
Fixed boot order

### DIFF
--- a/board/streamit/streamit-mlb400/streamit-mlb400.c
+++ b/board/streamit/streamit-mlb400/streamit-mlb400.c
@@ -139,10 +139,3 @@ int rk_board_late_init(void) {
     }
     return 0;
 }
-
-void board_boot_order(u32 *spl_boot_list)
-{
-	/* eMMC prior to sdcard. */
-	spl_boot_list[1] = BOOT_DEVICE_MMC2;
-	spl_boot_list[0] = BOOT_DEVICE_MMC1;
-}

--- a/include/configs/rockchip-common.h
+++ b/include/configs/rockchip-common.h
@@ -14,15 +14,15 @@
 /* First try to boot from SD (index 0), then eMMC (index 1 */
 #ifdef CONFIG_CMD_USB
 #define BOOT_TARGET_DEVICES(func) \
-	func(MMC, mmc, 0) \
 	func(MMC, mmc, 1) \
+	func(MMC, mmc, 0) \
 	func(USB, usb, 0) \
 	func(PXE, pxe, na) \
 	func(DHCP, dchp, na)
 #else
 #define BOOT_TARGET_DEVICES(func) \
-	func(MMC, mmc, 0) \
 	func(MMC, mmc, 1) \
+	func(MMC, mmc, 0) \
 	func(PXE, pxe, na) \
 	func(DHCP, dchp, na)
 #endif


### PR DESCRIPTION
The problem was caused by the indices of SD and eMMC being reversed (either just on our board or due to a bug in Rockchips MMC detection logic)